### PR TITLE
Fixing a bug when self identity is equal to 3

### DIFF
--- a/src/LinkableRingSignProver.cpp
+++ b/src/LinkableRingSignProver.cpp
@@ -77,7 +77,7 @@ void LinkableRingSignProver::GenerateSignature(string message, Integer &c1,
 	//initialise parameter for iteration
 	unsigned int i = (_self_identity + 2) % num_members;
 	
-	for(; i != _self_identity + 1; i = (i + 1) % num_members)
+	for(; i != (_self_identity + 1 % num_members); i = (i + 1) % num_members)
 	{
 		int j = (i - 1) % num_members;
 		si[j] = (Integer(rng, 0, q - 1));


### PR DESCRIPTION
We found that when you call to this for loop with self identity equal to 3 it just gets stuck on a infinite loop.